### PR TITLE
fix buffer over-read in fec_secded7264_decode()

### DIFF
--- a/fec_secded7264.c
+++ b/fec_secded7264.c
@@ -326,8 +326,8 @@ unsigned int fec_secded7264_decode(unsigned int _enc_msg_len,
         unsigned char c[8] = {0,0,0,0,0,0,0,0};     // decoded message
 
         unsigned int n;
-        // output length is input + 1 (parity byte)
-        for (n=0; n<r+1; n++)
+        // copy the remaining bytes to local buffer v
+        for (n=0; n<r; n++)
             v[n] = _msg_enc[j+n];
 
         // decode symbol


### PR DESCRIPTION
As described in #1, there is a buffer over-read in the function
fec_secded7264_decode() when copying the remaining bytes.

This bug was introduced by the commit 91621d9, which changed the
meaning of the first argument from the length of the original message
to encoded one.  If we get an original message length as it used to
be, we need additional byte for parity. However, we already know how
long the remaining bytes are, we can just copy it.  We must not copy
another one byte which leads us to illegal memory access.

Valgrind says:

$ valgrind ./fec_test
==11769== Memcheck, a memory error detector
==11769== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==11769== Using Valgrind-3.12.0 and LibVEX; rerun with -h for copyright info
==11769== Command: ./fec_test
==11769==
==11769== Invalid read of size 1
==11769==    at 0x10989B: fec_secded7264_decode (fec_secded7264.c:331)
==11769==    by 0x1087C9: main (main.c:50)
==11769==  Address 0x51d7069 is 0 bytes after a block of size 41 alloc'd
==11769==    at 0x4C2BBAF: malloc (vg_replace_malloc.c:299)
==11769==    by 0x10877D: main (main.c:40)
==11769==
Orig len 36 to enc len 41 to dec len 36 with 1 errors.
original: this is some text that is test data
corrupt:  this ms some0text 5hat is test data
decoded:  this is some text 5hat is test data
==11769==
==11769== HEAP SUMMARY:
==11769==     in use at exit: 0 bytes in 0 blocks
==11769==   total heap usage: 2 allocs, 2 frees, 1,065 bytes allocated
==11769==
==11769== All heap blocks were freed -- no leaks are possible
==11769==
==11769== For counts of detected and suppressed errors, rerun with: -v
==11769== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)

This fixes #1.